### PR TITLE
카드 엔티티 이름 및 관계  수정

### DIFF
--- a/src/cards/entities/card.entity.ts
+++ b/src/cards/entities/card.entity.ts
@@ -24,7 +24,7 @@ export class Card {
   list_id: number;
 
   @Column({ unique: true, type: 'varchar' })
-  name: string;
+  title: string;
 
   @Column({ type: 'text' })
   description: string;
@@ -71,9 +71,7 @@ export class Card {
   @JoinColumn()
   list: List;
 
-  @OneToMany((type): typeof Checklist => Checklist, (checklists) => checklists.card, {
-    cascade: true,
-  })
+  @OneToMany((type): typeof Checklist => Checklist, (checklists) => checklists.card, {})
   checklists: Checklist[];
 
   @OneToMany((type): typeof Comment => Comment, (comments) => comments.card, {})


### PR DESCRIPTION
 카드 엔티티 name말고 title이라고 표기하는 것이 가독성 있어보여 수정합니다